### PR TITLE
Allow undocking status bar item

### DIFF
--- a/MacMediaKeyForwarder/AppDelegate.m
+++ b/MacMediaKeyForwarder/AppDelegate.m
@@ -265,6 +265,11 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
     }
 }
 
+- (void)applicationDidBecomeActive:(NSNotification *)notification
+{
+    [statusItem setVisible:YES];
+}
+
 - ( void ) applicationDidFinishLaunching : ( NSNotification*) theNotification
 {
     // init containers
@@ -329,6 +334,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
     [ statusItem setToolTip : @"Mac Media Key Forwarder" ];
     [ statusItem setMenu : menu ];
     [ statusItem setImage : image ];
+    [ statusItem setBehavior : NSStatusItemBehaviorRemovalAllowed ];
     
     [self updateStartupItemState];
     [self updatePauseState];


### PR DESCRIPTION
It can be made to reappear by launching the app again while running.

--

I found the app today and really liked it! Though, I felt like one should just be able to set it up the way that makes sense to them, and then just forget about it.

--

For background applications such as this one, the `applicationDidBecomeActive:notification` hook is (as far as I'm aware) exclusively triggered by relaunching the app while it is still running. This makes it ideal for a lazy replacement of a preferences pane.