### PR TITLE
Change to com.apple.Music to make this work in Catalina

### DIFF
--- a/MacMediaKeyForwarder/AppDelegate.m
+++ b/MacMediaKeyForwarder/AppDelegate.m
@@ -101,7 +101,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
             return event;
         }
         
-        iTunesApplication *iTunes = [SBApplication applicationWithBundleIdentifier:@"com.apple.iTunes"];
+        iTunesApplication *iTunes = [SBApplication applicationWithBundleIdentifier:@"com.apple.Music"];
         SpotifyApplication *spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
         
         if ( pauseState == PauseStatePause )


### PR DESCRIPTION
Per https://github.com/milgra/macmediakeyforwarder/issues/82#issuecomment-520159888, change the `iTunesApplication` identifier to refer to Apple Music instead.

I haven't taken the time to alter any of the other string references to iTunes because I'm flat-out ragin' that this is even necessary, but more than happy to do so if it's desirable.

Have tested on my local machine and it does indeed forward the keypresses as expected.