### PR TITLE
Show correct now playing state on Touch Bar

### DIFF
--- a/MacMediaKeyForwarder.xcodeproj/project.pbxproj
+++ b/MacMediaKeyForwarder.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		33CD48CB1F867394000C454F /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 33CD48C71F8671B6000C454F /* icon.png */; };
 		33CD48CC1F867408000C454F /* icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 33CD48C91F86724F000C454F /* icon@2x.png */; };
 		33E2CC3E21B1361E002F8094 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33E2CC3D21B1361E002F8094 /* CoreServices.framework */; };
+		55CDEE8223A85654000E11D5 /* MediaRemote.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55CDEE8123A85654000E11D5 /* MediaRemote.framework */; };
 		A5999C4C1FF3BB89009905E1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A5999C4E1FF3BB89009905E1 /* Localizable.strings */; };
 		AA3E49F621AAA0C500EEA78B /* appicon.png in Resources */ = {isa = PBXBuildFile; fileRef = AA3E49F521AAA0C500EEA78B /* appicon.png */; };
 /* End PBXBuildFile section */
@@ -53,6 +54,7 @@
 		33CD48C71F8671B6000C454F /* icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon.png; sourceTree = "<group>"; };
 		33CD48C91F86724F000C454F /* icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon@2x.png"; sourceTree = "<group>"; };
 		33E2CC3D21B1361E002F8094 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
+		55CDEE8123A85654000E11D5 /* MediaRemote.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaRemote.framework; path = ../../../../System/Library/PrivateFrameworks/MediaRemote.framework; sourceTree = "<group>"; };
 		84B350D923526D6100255450 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A5999C4D1FF3BB89009905E1 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A5999C4F1FF3BB98009905E1 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33E2CC3E21B1361E002F8094 /* CoreServices.framework in Frameworks */,
+				55CDEE8223A85654000E11D5 /* MediaRemote.framework in Frameworks */,
 				33CD48BF1F866DB7000C454F /* ScriptingBridge.framework in Frameworks */,
 				336F74651E07E4F6009BCC1B /* CoreAudio.framework in Frameworks */,
 			);
@@ -136,6 +139,7 @@
 		336F74631E07E4F6009BCC1B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				55CDEE8123A85654000E11D5 /* MediaRemote.framework */,
 				33E2CC3D21B1361E002F8094 /* CoreServices.framework */,
 				3333F8912198687500816A9F /* GBLaunchAtLogin */,
 				33CD48BE1F866DB7000C454F /* ScriptingBridge.framework */,
@@ -395,6 +399,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.milgra.hsmke;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
 			};
 			name = Debug;
 		};
@@ -414,6 +419,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.milgra.hsmke;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "$(inherited) $(SYSTEM_LIBRARY_DIR)/PrivateFrameworks";
 			};
 			name = Release;
 		};

--- a/MacMediaKeyForwarder/AppDelegate.m
+++ b/MacMediaKeyForwarder/AppDelegate.m
@@ -464,7 +464,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
     if (![supportedApps containsObject:notification.userInfo[@"kMRMediaRemoteNowPlayingApplicationDisplayNameUserInfoKey"]]) {
         iTunesApplication *iTunes = [SBApplication applicationWithBundleIdentifier:[self iTunesBundleIdentifier]];
         SpotifyApplication *spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
-        if (([iTunes isRunning] && [iTunes playerState] == 1800426320) || ([spotify isRunning] && [spotify playerState] == SpotifyEPlSPlaying)) {
+        if (([iTunes isRunning] && [iTunes playerState] == iTunesEPlSPlaying) || ([spotify isRunning] && [spotify playerState] == SpotifyEPlSPlaying)) {
             NSLog(@"Set Touch Bar state to playing");
             MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), kMRPlaybackStatePlaying, dispatch_get_main_queue(), ^(MRMediaRemoteError error) {});
         } else {

--- a/MacMediaKeyForwarder/AppDelegate.m
+++ b/MacMediaKeyForwarder/AppDelegate.m
@@ -297,7 +297,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 - (NSString *)iTunesBundleIdentifier {
     if ( @available(macOS 10.15, *) )
     {
-        return @"com.apple.music";
+        return @"com.apple.Music";
     }
     else
     {

--- a/MacMediaKeyForwarder/AppDelegate.m
+++ b/MacMediaKeyForwarder/AppDelegate.m
@@ -444,7 +444,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 }
 
 - (void)checkMediaPlayers {
-    NSArray *supportedBundleIdentifiers = @[@"com.apple.Music", @"com.apple.iTunes"];
+    NSArray *supportedBundleIdentifiers = @[[self iTunesBundleIdentifier], @"com.spotify.client"];
     MRMediaRemoteGetNowPlayingClient(dispatch_get_main_queue(),
         ^(id clientObj) {
             if (nil != clientObj) {
@@ -460,17 +460,16 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
 - (void)handleExternalMediaPlayer:(NSNotification *)notification {
     [self checkMediaPlayers];
 
-    NSArray *supportedApps = @[@"Music", @"iTunes"];
+    NSArray *supportedApps = @[@"Music", @"iTunes", @"Spotify"];
     if (![supportedApps containsObject:notification.userInfo[@"kMRMediaRemoteNowPlayingApplicationDisplayNameUserInfoKey"]]) {
         iTunesApplication *iTunes = [SBApplication applicationWithBundleIdentifier:[self iTunesBundleIdentifier]];
-        if ([iTunes isRunning]) {
-            if ([iTunes playerState] == 1800426320) {
-                NSLog(@"Set Touch Bar state to playing");
-                MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), kMRPlaybackStatePlaying, dispatch_get_main_queue(), ^(MRMediaRemoteError error) {});
-            } else {
-                NSLog(@"Set Touch Bar state to stopped");
-                MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), kMRPlaybackStateStopped, dispatch_get_main_queue(), ^(MRMediaRemoteError error) {});
-            }
+        SpotifyApplication *spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
+        if (([iTunes isRunning] && [iTunes playerState] == 1800426320) || ([spotify isRunning] && [spotify playerState] == SpotifyEPlSPlaying)) {
+            NSLog(@"Set Touch Bar state to playing");
+            MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), kMRPlaybackStatePlaying, dispatch_get_main_queue(), ^(MRMediaRemoteError error) {});
+        } else {
+            NSLog(@"Set Touch Bar state to stopped");
+            MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin(MRMediaRemoteGetLocalOrigin(), kMRPlaybackStateStopped, dispatch_get_main_queue(), ^(MRMediaRemoteError error) {});
         }
     }
 }

--- a/MacMediaKeyForwarder/AppDelegate.m
+++ b/MacMediaKeyForwarder/AppDelegate.m
@@ -440,9 +440,10 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
         object:nil];
     MRMediaRemoteRegisterForNowPlayingNotifications(dispatch_get_main_queue());
     MRMediaRemoteSetCanBeNowPlayingApplication(YES);
+    [self checkMediaPlayers];
 }
 
-- (void)handleExternalMediaPlayer:(NSNotification *)notification {
+- (void)checkMediaPlayers {
     NSArray *supportedBundleIdentifiers = @[@"com.apple.Music", @"com.apple.iTunes"];
     MRMediaRemoteGetNowPlayingClient(dispatch_get_main_queue(),
         ^(id clientObj) {
@@ -454,6 +455,10 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
                 }
             }
     });
+}
+
+- (void)handleExternalMediaPlayer:(NSNotification *)notification {
+    [self checkMediaPlayers];
 
     NSArray *supportedApps = @[@"Music", @"iTunes"];
     if (![supportedApps containsObject:notification.userInfo[@"kMRMediaRemoteNowPlayingApplicationDisplayNameUserInfoKey"]]) {


### PR DESCRIPTION
This pull request stops non-music apps from changing the Touch Bar now playing state while music is playing as Mac Media Key Forwarder controls the music (fixes https://github.com/milgra/macmediakeyforwarder/issues/100).

To achieve this the undocumented [MediaRemote](http://iphonedevwiki.net/index.php/MediaRemote.framework) framework is used. The following sources were used to achieve this solution:
- The WebKit source
- GitHub repos with the `MediaRemote.h` header
- Disassembling the MediaRemote private framework using Hopper and `nm`
- A lot of trial and error

After listening to the `kMRMediaRemoteNowPlayingApplicationIsPlayingDidChangeNotification` event two crucial functions are called:
- `MRMediaRemoteSetNowPlayingApplicationOverrideEnabled`
This stops other applications from changing the now playing state in the Touch Bar.
- `MRMediaRemoteSetNowPlayingApplicationPlaybackStateForOrigin`
This updates the actual now playing state, without the override method above this will only work once per session.

Alternative solutions that were investigated:
- Calling `MRMediaRemoteSendCommandToApp` to simulate sending a play event (`MRMediaRemoteSendCommand` sends it to the app that has focus), the method signature seems to require a complex Protobuf object though.
- Calling `MRNowPlayingClientSetBundleIdentifier` to set Music or Spotify to be the active app, this requires a `MRNowPlayingClientProtobuf` object though.
- Calling `[iTunes playpause]` twice to seize control back to the Music app. This is not ideal as this results in a brief pause.
- Simply calling `[iTunes playpause]` when media from another app starts to play. This ensures the now playing state is correct but stops music playback.
- If the MediaRemote framework could not be used, the `NPUNowPlayingControllerNowPlayingInfoDidChange` notification could possibly be listened to with the right header file included.

Spotify is supported but there is an issue where the Touch Bar will not update from within Spotify when the play button is used even without Mac Media Key Forwarder installed. This is beyond the scope of this application but could be fixed by Spotify or by creating a new tool from this code.

The bundle identifier was changed to the proper case for the Music app as string matching is used to check for it, when using Apple Events the case doesn't seem to matter.